### PR TITLE
fix: update to 1.0.0 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 keywords = ["changelog", "changelog-generator", "commit-style"]
 dependencies = [
-    "git-changelog >= 0.6.0",
+    "git-changelog = 1.0.0",
 ]
 requires-python = ">=3.7"
 

--- a/src/rhenvision_changelog/changelog.py
+++ b/src/rhenvision_changelog/changelog.py
@@ -46,7 +46,7 @@ class ProvisioningChangelog(Changelog):
         namespace, project = "/".join(split[3:-1]), split[-1]
 
         provider = GitHubJiraProvider(namespace, project, jira_url, jira_project)
-        super().__init__(repository, provider=provider, style="angular")
+        super().__init__(repository, provider=provider, convention="angular")
 
     def get_log(self) -> str:
         """Get the `git log` output possibly limited by limit passed to constructor.

--- a/src/rhenvision_changelog/changelog.py
+++ b/src/rhenvision_changelog/changelog.py
@@ -46,7 +46,7 @@ class ProvisioningChangelog(Changelog):
         namespace, project = "/".join(split[3:-1]), split[-1]
 
         provider = GitHubJiraProvider(namespace, project, jira_url, jira_project)
-        super().__init__(repository, provider=provider, convention="angular")
+        super().__init__(repository, provider=provider, convention="angular", parse_provider_refs=True)
 
     def get_log(self) -> str:
         """Get the `git log` output possibly limited by limit passed to constructor.

--- a/src/rhenvision_changelog/commit_check.py
+++ b/src/rhenvision_changelog/commit_check.py
@@ -5,13 +5,13 @@ def check_commit(commit, jira_project, length_limit=70) -> int:
         sys.stderr.write("ERROR: Commit message length too long (limit is " + length_limit + "): " + commit.subject + "\n")
         return 1
 
-    if commit.style["type"] == "":
+    if commit.convention["type"] == "":
         sys.stderr.write("ERROR: Commit message must have a type 'type: subject': " + commit.subject + "\n")
         return 2
 
-    if commit.style["type"] in ["Features", "Bug Fixes"]:
-        if commit.style["scope"] is not None and jira_project not in commit.style["scope"]:
-            sys.stderr.write("ERROR: Scope for Feature and Bug fix needs to be Jira issue in format '"+jira_project+"-XXX': " + commit.style["scope"] + "\n")
+    if commit.convention["type"] in ["Features", "Bug Fixes"]:
+        if commit.convention["scope"] is not None and jira_project not in commit.convention["scope"]:
+            sys.stderr.write("ERROR: Scope for Feature and Bug fix needs to be Jira issue in format '"+jira_project+"-XXX': " + commit.convention["scope"] + "\n")
             return 2
 
         if "issues" not in commit.text_refs or len(commit.text_refs["issues"]) == 0:


### PR DESCRIPTION
Upstream has finally reached 1.0.0 I am pinning this release.

The problem we have is this rename:

https://github.com/pawamoy/git-changelog/commit/ee6f0e9bd56557c543b26ceb8ebf0a4ca55397c5#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR51