### PR TITLE
restore deleted setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = rhenvision-changelog
+version = 0.1.0
+
+[options]
+include_package_data=True
+package_dir=
+    =src
+packages=find:
+install_requires=
+    git-changelog >= 2.0
+
+[options.extras_require]
+test=
+    pytest
+
+[options.packages.find]
+    where=src


### PR DESCRIPTION
Looks like `setup.cfg` is still needed on GHA CI for some reason:

```
 pip3 install ./changelog
  shell: /usr/bin/bash -e {0}
  env:
    GO_SVR: 1.19.6
Defaulting to user installation because normal site-packages is not writeable
Processing ./changelog
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: UNKNOWN
  Building wheel for UNKNOWN (pyproject.toml): started
  Building wheel for UNKNOWN (pyproject.toml): finished with status 'done'
  Created wheel for UNKNOWN: filename=UNKNOWN-0.0.0-py3-none-any.whl size=13170 sha256=628fa45145c4eefcb731f3343005b162467a58a3f225778f267881d03f889ac2
  Stored in directory: /tmp/pip-ephem-wheel-cache-93rqlayk/wheels/d3/ed/73/49464ab3f55b51029de23c1b2baa1adae910909f009b349f32
Successfully built UNKNOWN
Installing collected packages: UNKNOWN
Successfully installed UNKNOWN-0.0.0
```

No idea what is going on. And why there are two "project" files.